### PR TITLE
Fix self-closing element not allowed in javadoc

### DIFF
--- a/src/main/java/com/tdunning/sparse/Trace.java
+++ b/src/main/java/com/tdunning/sparse/Trace.java
@@ -10,7 +10,7 @@ import java.io.*;
 
 /**
  * Reads an EKG trace from the format provided by physio.net
- * <p/>
+ * <p></p>
  * This format contains a matrix of 16bit numbers in row major order.
  */
 public class Trace {


### PR DESCRIPTION
Under Java 1.8 and Maven 3.3.9 `mvn install` produces an error while trying to generate the javadoc. 

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9
.1:jar (attach-javadocs) on project AnomalyDetector: MavenReportException: Error
 while creating archive:
[ERROR] Exit code: 1 - C:\Users\ecerulm\Documents\GitHub\anomaly-detection\src\m
ain\java\com\tdunning\sparse\Trace.java:13: error: self-closing element not allo
wed
[ERROR] * <p/>
[ERROR] ^
[ERROR]
[ERROR] Command line was: "C:\Program Files\Java\jdk1.8.0_31\jre\..\bin\javadoc.
exe" @options @packages
```

Seems that the self-closing tag <p/> is not allowed so I changed it to <p></p>
